### PR TITLE
終了後のルーティングを変更

### DIFF
--- a/lib/presentation/pages/category_select_page.dart
+++ b/lib/presentation/pages/category_select_page.dart
@@ -8,7 +8,7 @@ class CategorySelectPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        AppBar(title: const Text('ユニット選択')),
+        AppBar(title: const Text('カテゴリー選択')),
         Expanded(
           child: Center(
             child: Column(

--- a/lib/presentation/pages/unit_finish_page.dart
+++ b/lib/presentation/pages/unit_finish_page.dart
@@ -85,12 +85,36 @@ class UnitFinishPage extends ConsumerWidget {
 
             const Spacer(),
 
-            /// ボタン
-            ElevatedButton(
-              onPressed: () {
-                context.go('/'); // ホームへ
-              },
-              child: const Text('ホームへ戻る'),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () {
+                      context.go('/training');
+                    },
+                    child: const Text('メニュー'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () {
+                      context.go('/training/category');
+                    },
+                    child: const Text('カテゴリー'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {
+                      context.go(
+                          '/training/category/unit?categoryId=${game.categoryId}');
+                    },
+                    child: const Text('ユニット選択'),
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -36,7 +36,8 @@ final GoRouter appRouter = GoRouter(
                   GoRoute(
                       path: 'unit',
                       builder: (context, state) => UnitSelectPage(
-                            categoryId: 1,
+                            categoryId: int.parse(
+                                state.uri.queryParameters['categoryId'] ?? '0'),
                           ),
                       routes: [
                         GoRoute(

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -36,8 +36,10 @@ final GoRouter appRouter = GoRouter(
                   GoRoute(
                       path: 'unit',
                       builder: (context, state) => UnitSelectPage(
-                            categoryId: int.parse(
-                                state.uri.queryParameters['categoryId'] ?? '0'),
+                            categoryId: int.tryParse(
+                                  state.uri.queryParameters['categoryId'] ?? '',
+                                ) ??
+                                0,
                           ),
                       routes: [
                         GoRoute(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * カテゴリー選択ページの表示ラベルを更新
  * ユニット完了画面のナビゲーションを強化し、トレーニング、カテゴリー選択、ユニット選択へのダイレクトアクセスが可能に

<!-- end of auto-generated comment: release notes by coderabbit.ai -->