### PR TITLE
unitカードの色を星の数に合わせて変更。さらにテストを追加

### DIFF
--- a/lib/presentation/theme/unit_card_style.dart
+++ b/lib/presentation/theme/unit_card_style.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class UnitCardStyle {
+  final Color backgroundColor;
+  final Color borderColor;
+  final Color textColor;
+  final Color starColor;
+
+  const UnitCardStyle({
+    required this.backgroundColor,
+    required this.borderColor,
+    required this.textColor,
+    required this.starColor,
+  });
+}

--- a/lib/presentation/theme/unit_card_styles.dart
+++ b/lib/presentation/theme/unit_card_styles.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'unit_card_style.dart';
+
+class UnitCardStyles {
+  static UnitCardStyle fromStars(int stars) {
+    switch (stars) {
+      case 0:
+        return const UnitCardStyle(
+          backgroundColor: Color(0xFFECEFF1),
+          borderColor: Color(0xFFCFD8DC),
+          textColor: Color(0xDD000000),
+          starColor: Color(0xFF9E9E9E),
+        );
+
+      case 1:
+        return const UnitCardStyle(
+          backgroundColor: Color(0xFFE3F2FD),
+          borderColor: Color(0xFF90CAF9),
+          textColor: Color(0xDD000000),
+          starColor: Color(0xFF2196F3),
+        );
+
+      case 2:
+        return const UnitCardStyle(
+          backgroundColor: Color(0xFFE8F5E9),
+          borderColor: Color(0xFFA5D6A7),
+          textColor: Color(0xDD000000),
+          starColor: Color(0xFF4CAF50),
+        );
+
+      case 3:
+        return const UnitCardStyle(
+          backgroundColor: Color(0xFFFFF9C4),
+          borderColor: Color(0xFFFFF176),
+          textColor: Color(0xDD000000),
+          starColor: Color(0xFFFFC107),
+        );
+
+      case 4:
+        return const UnitCardStyle(
+          backgroundColor: Color(0xFFFFE0B2),
+          borderColor: Color(0xFFFFB74D),
+          textColor: Color(0xDD000000),
+          starColor: Color(0xFFFF9800),
+        );
+
+      case 5:
+        return const UnitCardStyle(
+          backgroundColor: Color(0xFFFFD54F),
+          borderColor: Color(0xFFFFA000),
+          textColor: Color(0xDD000000),
+          starColor: Color(0xFFFFC107),
+        );
+
+      default:
+        return const UnitCardStyle(
+          backgroundColor: Color(0xFFFFFFFF),
+          borderColor: Color(0xFF9E9E9E),
+          textColor: Color(0xDD000000),
+          starColor: Color(0xFF9E9E9E),
+        );
+    }
+  }
+}

--- a/lib/presentation/widgets/unit_card_widget.dart
+++ b/lib/presentation/widgets/unit_card_widget.dart
@@ -1,3 +1,4 @@
+import 'package:flash_english/presentation/theme/unit_card_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -21,6 +22,7 @@ class UnitCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final style = UnitCardStyles.fromStars(stars);
     return InkWell(
       onTap: () {
         context.push(
@@ -29,8 +31,13 @@ class UnitCard extends StatelessWidget {
       },
       borderRadius: BorderRadius.circular(16),
       child: Card(
+        color: style.backgroundColor,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
+          side: BorderSide(
+            color: style.borderColor,
+            width: 2,
+          ),
         ),
         elevation: 4,
         child: Padding(
@@ -52,7 +59,7 @@ class UnitCard extends StatelessWidget {
                   final star = stars;
                   return Icon(
                     i < star ? Icons.star : Icons.star_border,
-                    color: i < star ? Colors.amber : Colors.grey,
+                    color: i < star ? style.starColor : Colors.grey,
                     size: 16,
                   );
                 }),
@@ -62,7 +69,7 @@ class UnitCard extends StatelessWidget {
                 dateText,
                 style: TextStyle(
                   fontSize: 11,
-                  color: Colors.grey.shade600,
+                  color: style.textColor,
                 ),
               ),
             ],

--- a/lib/presentation/widgets/unit_card_widget.dart
+++ b/lib/presentation/widgets/unit_card_widget.dart
@@ -22,7 +22,8 @@ class UnitCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = UnitCardStyles.fromStars(stars);
+    final normalizedStars = stars.clamp(0, 5);
+    final style = UnitCardStyles.fromStars(normalizedStars);
     return InkWell(
       onTap: () {
         context.push(
@@ -56,7 +57,7 @@ class UnitCard extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: List.generate(5, (i) {
-                  final star = stars;
+                  final star = normalizedStars;
                   return Icon(
                     i < star ? Icons.star : Icons.star_border,
                     color: i < star ? style.starColor : Colors.grey,

--- a/test/domain/entities/study_log_test.dart
+++ b/test/domain/entities/study_log_test.dart
@@ -60,4 +60,96 @@ void main() {
       expect(log.durationSeconds, 15);
     });
   });
+
+  group('StudyLog.toJson', () {
+    test('正しく JSON に変換できる', () {
+      final createdAt = DateTime.utc(2026, 4, 19, 12, 30, 45);
+
+      final log = StudyLog(
+        id: 1,
+        categoryNo: 10,
+        unitNo: 20,
+        questionNo: 30,
+        isCorrect: true,
+        sessionId: 99,
+        durationSeconds: 12,
+        createdAt: createdAt,
+      );
+
+      final json = log.toJson();
+
+      expect(json['id'], 1);
+      expect(json['category_no'], 10);
+      expect(json['unit_no'], 20);
+      expect(json['question_no'], 30);
+      expect(json['is_correct'], true);
+      expect(json['session_id'], 99);
+      expect(json['duration_seconds'], 12);
+      expect(
+        json['created_at'],
+        createdAt.toUtc().toIso8601String(),
+      );
+    });
+
+    test('id が null の場合も JSON 変換できる', () {
+      final log = StudyLog(
+        categoryNo: 1,
+        unitNo: 2,
+        questionNo: 3,
+        isCorrect: false,
+        sessionId: 4,
+        durationSeconds: 5,
+        createdAt: DateTime.utc(2026, 4, 19),
+      );
+
+      final json = log.toJson();
+
+      expect(json['id'], isNull);
+      expect(json['category_no'], 1);
+      expect(json['unit_no'], 2);
+      expect(json['question_no'], 3);
+      expect(json['is_correct'], false);
+      expect(json['session_id'], 4);
+      expect(json['duration_seconds'], 5);
+    });
+
+    test('created_at は UTC ISO8601 形式で出力される', () {
+      final localTime = DateTime(2026, 4, 19, 21, 15, 30);
+
+      final log = StudyLog(
+        categoryNo: 1,
+        unitNo: 1,
+        questionNo: 1,
+        isCorrect: true,
+        sessionId: 1,
+        durationSeconds: 1,
+        createdAt: localTime,
+      );
+
+      final json = log.toJson();
+
+      expect(
+        json['created_at'],
+        localTime.toUtc().toIso8601String(),
+      );
+    });
+
+    test('durationSeconds が 0 でも保持できる', () {
+      final log = StudyLog(
+        categoryNo: 1,
+        unitNo: 1,
+        questionNo: 1,
+        isCorrect: true,
+        sessionId: 1,
+        durationSeconds: 0,
+        createdAt: DateTime.utc(2026, 4, 19),
+      );
+
+      expect(log.durationSeconds, 0);
+
+      final json = log.toJson();
+
+      expect(json['duration_seconds'], 0);
+    });
+  });
 }

--- a/test/domain/entities/unit_score_test.dart
+++ b/test/domain/entities/unit_score_test.dart
@@ -147,4 +147,123 @@ void main() {
       expect(result.isPerfect, true);
     });
   });
+
+  group('UnitScore.toJson', () {
+    test('正しく JSON に変換できる', () {
+      final unitScore = UnitScore(
+        categoryNo: 2,
+        unitNo: 5,
+        score: 8,
+        achievedAt: '2026/05/24',
+      );
+
+      final json = unitScore.toJson();
+
+      expect(json['category_no'], 2);
+      expect(json['unit_no'], 5);
+      expect(json['high_score'], 8);
+      expect(json['achieved_at'], '2026/05/24');
+    });
+  });
+
+  group('UnitScore.toMap', () {
+    test('正しく Map に変換できる', () {
+      final unitScore = UnitScore(
+        categoryNo: 3,
+        unitNo: 9,
+        score: 10,
+        achievedAt: '2026/05/24',
+      );
+
+      final map = unitScore.toMap();
+
+      expect(map['category_no'], 3);
+      expect(map['unit_no'], 9);
+      expect(map['score'], 10);
+      expect(map['achieved_at'], '2026/05/24');
+    });
+  });
+
+  group('UnitScore stars boundary', () {
+    test('score=6 は ★3', () {
+      final unitScore = UnitScore(
+        categoryNo: 1,
+        unitNo: 1,
+        score: 6,
+        achievedAt: '',
+      );
+
+      expect(unitScore.stars, 3);
+    });
+
+    test('score=7 は ★4', () {
+      final unitScore = UnitScore(
+        categoryNo: 1,
+        unitNo: 1,
+        score: 7,
+        achievedAt: '',
+      );
+
+      expect(unitScore.stars, 4);
+    });
+
+    test('score=9 は ★4', () {
+      final unitScore = UnitScore(
+        categoryNo: 1,
+        unitNo: 1,
+        score: 9,
+        achievedAt: '',
+      );
+
+      expect(unitScore.stars, 4);
+    });
+
+    test('score=10 は ★5', () {
+      final unitScore = UnitScore(
+        categoryNo: 1,
+        unitNo: 1,
+        score: 10,
+        achievedAt: '',
+      );
+
+      expect(unitScore.stars, 5);
+    });
+  });
+
+  group('UnitScore.fromJson invalid types', () {
+    test('型が不正な場合は例外が発生する', () {
+      final json = {
+        'category_no': 'abc',
+        'unit_no': 'def',
+        'high_score': 'ghi',
+        'achieved_at': 123,
+      };
+
+      expect(
+        () => UnitScore.fromJson(json),
+        throwsA(isA<TypeError>()),
+      );
+    });
+  });
+
+  group('UnitScore serialization round trip', () {
+    test('toJson → fromJson で値を維持できる', () {
+      final original = UnitScore(
+        categoryNo: 4,
+        unitNo: 2,
+        score: 9,
+        achievedAt: '2026/05/24',
+      );
+
+      final json = original.toJson();
+      final restored = UnitScore.fromJson(json);
+
+      expect(restored.categoryNo, original.categoryNo);
+      expect(restored.unitNo, original.unitNo);
+      expect(restored.score, original.score);
+      expect(restored.achievedAt, original.achievedAt);
+      expect(restored.stars, original.stars);
+      expect(restored.isPerfect, original.isPerfect);
+    });
+  });
 }

--- a/test/presentation/theme/unit_card_styles_test.dart
+++ b/test/presentation/theme/unit_card_styles_test.dart
@@ -1,0 +1,65 @@
+import 'package:flash_english/presentation/theme/unit_card_styles.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('UnitCardStyles.fromStars', () {
+    test('returns style for 0 stars', () {
+      final style = UnitCardStyles.fromStars(0);
+
+      expect(style.backgroundColor, const Color(0xFFECEFF1));
+      expect(style.borderColor, const Color(0xFFCFD8DC));
+      expect(style.textColor, const Color(0xDD000000));
+      expect(style.starColor, const Color(0xFF9E9E9E));
+    });
+
+    test('returns style for 1 star', () {
+      final style = UnitCardStyles.fromStars(1);
+
+      expect(style.backgroundColor, const Color(0xFFE3F2FD));
+      expect(style.borderColor, const Color(0xFF90CAF9));
+      expect(style.starColor, const Color(0xFF2196F3));
+    });
+
+    test('returns style for 2 stars', () {
+      final style = UnitCardStyles.fromStars(2);
+
+      expect(style.backgroundColor, const Color(0xFFE8F5E9));
+      expect(style.borderColor, const Color(0xFFA5D6A7));
+      expect(style.starColor, const Color(0xFF4CAF50));
+    });
+
+    test('returns style for 3 stars', () {
+      final style = UnitCardStyles.fromStars(3);
+
+      expect(style.backgroundColor, const Color(0xFFFFF9C4));
+      expect(style.borderColor, const Color(0xFFFFF176));
+      expect(style.starColor, const Color(0xFFFFC107));
+    });
+
+    test('returns style for 4 stars', () {
+      final style = UnitCardStyles.fromStars(4);
+
+      expect(style.backgroundColor, const Color(0xFFFFE0B2));
+      expect(style.borderColor, const Color(0xFFFFB74D));
+      expect(style.starColor, const Color(0xFFFF9800));
+    });
+
+    test('returns style for 5 stars', () {
+      final style = UnitCardStyles.fromStars(5);
+
+      expect(style.backgroundColor, const Color(0xFFFFD54F));
+      expect(style.borderColor, const Color(0xFFFFA000));
+      expect(style.starColor, const Color(0xFFFFC107));
+    });
+
+    test('returns default style for invalid value', () {
+      final style = UnitCardStyles.fromStars(999);
+
+      expect(style.backgroundColor, const Color(0xFFFFFFFF));
+      expect(style.borderColor, const Color(0xFF9E9E9E));
+      expect(style.textColor, const Color(0xDD000000));
+      expect(style.starColor, const Color(0xFF9E9E9E));
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ユニットカードの見た目を一元管理するスタイルを導入。星の数（0〜5）に応じてカード背景・枠線・テキスト・星アイコンの色が動的に変わり、獲得済み/未獲得の星表示や日付テキストの色も反映されます。

* **テスト**
  * 学習記録、ユニットスコア、カードスタイルの振る舞いを検証する包括的な単体テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HonjyouDaisuke/flash_english/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->